### PR TITLE
HTTP 500 errors when trying to select sites, variables and plots for …

### DIFF
--- a/archive_api/serializers.py
+++ b/archive_api/serializers.py
@@ -134,8 +134,20 @@ class DataSetSerializer(serializers.HyperlinkedModelSerializer):
         with transaction.atomic():
             # Pop off authors data, if exists
             author_data = []
+            sites_data = []
+            plots_data = []
+            variables_data = []
             if "authors" in validated_data.keys():
                 author_data = validated_data.pop('authors')
+
+            if "sites" in validated_data.keys():
+                sites_data = validated_data.pop('sites')
+
+            if "plots" in validated_data.keys():
+                plots_data = validated_data.pop('plots')
+
+            if "variables" in validated_data.keys():
+                variables_data = validated_data.pop('variables')
 
             # Create dataset first
             dataset = DataSet.objects.create(**validated_data)
@@ -144,6 +156,14 @@ class DataSetSerializer(serializers.HyperlinkedModelSerializer):
 
             # save the author data
             self.add_authors(author_data, dataset)
+            for obj in sites_data:
+                dataset.sites.add(obj)
+            for obj in plots_data:
+                dataset.plots.add(obj)
+            for obj in variables_data:
+                dataset.variables.add(obj)
+
+            dataset.save()
 
         return dataset
 

--- a/archive_api/tests/test_api.py
+++ b/archive_api/tests/test_api.py
@@ -59,12 +59,33 @@ class DataSetClientTestCase(APITestCase):
         for mime_type in DatasetArchiveField.CONTENT_TYPES:
             self.assertContains(response, mime_type)
 
+    def test_issue_74(self):
+        self.login_user("auser")
+        response = self.client.post('/api/v1/datasets/',
+                                    data='{"description":"A FooBarBaz DataSet",'
+                                         '"authors":["http://testserver/api/v1/people/2/"],'
+                                         '"sites":["http://testserver/api/v1/sites/1/"] ,'
+                                         '"plots":["http://testserver/api/v1/plots/1/"],'
+                                         '"variables":["http://testserver/api/v1/variables/1/"]  }',
+                                    content_type='application/json')
+
+        self.assertTrue(status.HTTP_201_CREATED,response.status_code)
+
+        response = self.client.get('/api/v1/datasets/4/')
+
+        self.assertContains(response,
+                            "http://testserver/api/v1/variables/1/")
+        self.assertContains(response,
+                            "http://testserver/api/v1/sites/1/")
+        self.assertContains(response,
+                            "http://testserver/api/v1/plots/1/")
+
 
     def test_client_unnamed(self):
         self.login_user("auser")
         response = self.client.post('/api/v1/datasets/',
                                     data='{"description":"A FooBarBaz DataSet",'
-                                         '"authors":["http://testserver/api/v1/people/2/"] }',
+                                         '"authors":["http://testserver/api/v1/people/2/"]  }',
                                     content_type='application/json')
         self.assertEqual(status.HTTP_201_CREATED, response.status_code)
 


### PR DESCRIPTION
HTTP 500 errors when trying to select sites, variables and plots for creating datasets

Resolves #74

The fix is to save the dataset first without the plots, sites and variables in the serializer create method