### PR TITLE
500 error while creating datasets

### DIFF
--- a/ngt_archive/settings.py
+++ b/ngt_archive/settings.py
@@ -15,6 +15,9 @@ import sys
 
 import os
 
+
+EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
+
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # Quick-start development settings - unsuitable for production


### PR DESCRIPTION
Resolves #106

This was an issue with the development server email backed.  The solution was to set a default backend for local testing.