### PR TITLE
Is the backend enforcing a file size limit?

### DIFF
--- a/archive_api/models.py
+++ b/archive_api/models.py
@@ -72,9 +72,9 @@ class DatasetArchiveStorage(FileSystemStorage):
 
         from django.conf import settings
         if "location" not in kwargs:
-            kwargs["location"]=settings.DATASET_ARCHIVE_ROOT
+            kwargs["location"]=settings.ARCHIVE_API['DATASET_ARCHIVE_ROOT']
         if "base_url" not in kwargs:
-            kwargs["base_url"] = settings.DATASET_ARCHIVE_URL
+            kwargs["base_url"] = settings.ARCHIVE_API['DATASET_ARCHIVE_URL']
         super(DatasetArchiveStorage, self).__init__(*args, **kwargs)
 
 

--- a/ngt_archive/settings.py
+++ b/ngt_archive/settings.py
@@ -16,6 +16,7 @@ import sys
 import os
 
 
+
 EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -150,8 +151,16 @@ REST_FRAMEWORK = {
 STATIC_ROOT = "static/"
 STATIC_URL = '/static/'
 
-DATASET_ARCHIVE_ROOT = os.path.join(BASE_DIR, "archives/")
-DATASET_ARCHIVE_URL = '/archives/' # not used
+ARCHIVE_API = {
+    'DATASET_ARCHIVE_ROOT': os.path.join(BASE_DIR, "archives/"),
+    'DATASET_ARCHIVE_URL': '/archives/',  # not used
+    'DATASET_ADMIN_MAX_UPLOAD_SIZE': 2147483648, # in bytes
+    'DATASET_USER_MAX_UPLOAD_SIZE': 1073741824, # in bytes
+    'EMAIL_NGEET_TEAM': 'ngeet-team@testserver',
+    'EMAIL_SUBJECT_PREFIX' : '[ngt-archive-test]'
+
+}
+
 
 try:
     try:

--- a/settings_local_py.jinja2
+++ b/settings_local_py.jinja2
@@ -3,8 +3,6 @@ import ldap
 EMAIL_BACKEND = 'django.core.mail.backends.filebased.EmailBackend'
 EMAIL_FILE_PATH = '/tmp/app-messages' # change this to a proper location
 
-ARCHIVE_API_EMAIL_NGEET_TEAM = 'ngeet-team@testserver'
-ARCHIVE_API_EMAIL_SUBJECT_PREFIX = '[ngt-archive-test]'
 
 DEBUG = True
 


### PR DESCRIPTION
Resolves #117

Added the ability to set a file size limit for admin and regular users. Enforcing the limit in the DataSetViewSet.upload function.
This will prevent the admin or user to upload file sizes larger than the specified limits while allowing the django website admin to upload files of arbitrarily large sizes.

This fix also introduces a reorganization of the archive api settings into a dictionary.