### PR TITLE
All Dataset downloads should be logged

### DIFF
--- a/archive_api/admin.py
+++ b/archive_api/admin.py
@@ -1,7 +1,8 @@
+
 from django.contrib import admin
 from django.contrib.admin import ModelAdmin
-
-from archive_api.models import MeasurementVariable, Site, Person, Plot
+from daterange_filter.filter import DateRangeFilter
+from archive_api.models import MeasurementVariable, Site, Person, Plot, DataSetDownloadLog
 
 
 @admin.register(MeasurementVariable)
@@ -22,3 +23,94 @@ class PlotAdmin(ModelAdmin):
 @admin.register(Site)
 class SiteAdmin(ModelAdmin):
     list_display = ('site_id', 'name', 'description',)
+
+
+@admin.register(DataSetDownloadLog)
+class DataSetDownloadLogAdmin(ModelAdmin):
+    """
+    This Admin interface allows user to search by date range and user.  The resulting items
+    in the list may be downloaded to a CSV file
+    """
+    list_filter = (('datetime',DateRangeFilter),'user',)
+    actions = ('download_csv',)
+    list_display = ('datetime', 'user_name', 'dataset_status', 'dataset', 'request_url',)
+    readonly_fields = ('datetime', 'user', 'dataset_status', 'dataset', 'request_url', 'ip_address')
+
+    fieldsets = [
+        (None, {'fields': ()}),
+    ]
+
+    def __init__(self, *args, **kwargs):
+        """
+        Override the parent method in order to remove display links
+        that navigate to show info page.
+        :param args:
+        :param kwargs:
+        """
+        super(self.__class__, self).__init__(*args, **kwargs)
+        self.list_display_links = None  # no display links
+
+    def has_add_permission(self, request):
+        """
+        Disallow add through the admin interface. These records
+        should only be created when a DataSet archive file is downloaded
+        :param request:
+        :return:
+        """
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        """
+        Disallow delete from anywhere in the admin interface.  These records are
+        never to be deleted.
+
+        :param request:
+        :param obj:
+        :return:
+        """
+        return False
+
+    def user_name(self, obj):
+        """
+        Format the user name with full name and email address.
+        :param obj:
+        :return:
+        """
+        return "{} <{}>".format(obj.user.get_full_name(), obj.user.email)
+
+    def get_actions(self, request):
+        """Overrides parent. Removed the delete selected action"""
+        actions = super(self.__class__, self).get_actions(request)
+        if 'delete_selected' in actions:
+            del actions['delete_selected']
+        return actions
+
+    def download_csv(self, request, queryset):
+        """
+        Allow users to download the selected records
+
+        :param request:
+        :param queryset:
+        :return:
+        """
+        import csv
+        from django.http import HttpResponse
+        import io
+
+        f = io.StringIO()
+        writer = csv.writer(f)
+        writer.writerow(["datetime", "user_name", "dataset_status", 'dataset_name', "ip_address", "request_url"])
+
+        for row in queryset:
+            writer.writerow([row.datetime, self.user_name(row),row.get_dataset_status_display(),
+                             str(row.dataset), row.ip_address, row.request_url
+                             ])
+
+        f.seek(0)
+        response = HttpResponse(f, content_type='text/csv')
+        response['Content-Disposition'] = 'attachment; filename=download_log.csv'
+        return response
+
+    download_csv.short_description = "Download CSV file for selected download activity."
+
+

--- a/archive_api/migrations/0001_initial.py
+++ b/archive_api/migrations/0001_initial.py
@@ -237,4 +237,20 @@ class Migration(migrations.Migration):
             name='author',
             unique_together={('dataset', 'order', 'author')},
         ),
+        migrations.CreateModel(
+            name='DataSetDownloadLog',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('dataset_status',
+                 models.CharField(choices=[('0', 'Draft'), ('1', 'Submitted'), ('2', 'Approved')], default='0',
+                                  max_length=1)),
+                ('request_url', models.CharField(max_length=256)),
+                ('datetime', models.DateTimeField(auto_now_add=True)),
+                ('ip_address', models.GenericIPAddressField(blank=True, null=True)),
+                (
+                'dataset', models.ForeignKey(on_delete=django.db.models.deletion.DO_NOTHING, to='archive_api.DataSet')),
+                (
+                'user', models.ForeignKey(on_delete=django.db.models.deletion.DO_NOTHING, to=settings.AUTH_USER_MODEL)),
+            ],
+        )
     ]

--- a/archive_api/models.py
+++ b/archive_api/models.py
@@ -325,6 +325,15 @@ class DataSet(models.Model):
                 else: self.ngt_id=0 # only for the very first dataset
             super(DataSet, self).save(*args, **kwargs)
 
+    def __str__(self):
+        return self.__unicode__()
+
+    def __unicode__(self):
+        return '{}-v{}: {}'.format(self.data_set_id(), self.version, self.name)
+
+    def __repr__(self):
+        return '<DataSet {}>'.format(self)
+
 
 class Author(models.Model):
     """ Model for storing data about the Author relationship between DataSet and Person """
@@ -335,3 +344,14 @@ class Author(models.Model):
     class Meta:
         unique_together = ('dataset', 'order', 'author')
         ordering = ('dataset', 'order')
+
+
+class DataSetDownloadLog(models.Model):
+    """Logs archive downloads"""
+
+    user = models.ForeignKey(settings.AUTH_USER_MODEL,on_delete=models.DO_NOTHING)
+    dataset = models.ForeignKey(DataSet,on_delete=models.DO_NOTHING)
+    dataset_status  = models.CharField(max_length=1, choices=STATUS_CHOICES)  # (draft [DEFAULT], submitted, approved)
+    request_url = models.CharField(max_length=256)
+    datetime = models.DateTimeField(editable=False, auto_now_add=True)
+    ip_address = models.GenericIPAddressField(blank=True, null=True)

--- a/archive_api/tests/test_api.py
+++ b/archive_api/tests/test_api.py
@@ -11,7 +11,7 @@ from os.path import dirname
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from archive_api.models import DatasetArchiveField
+from archive_api.models import DatasetArchiveField, DataSetDownloadLog
 from ngt_archive import settings
 
 
@@ -540,6 +540,10 @@ class DataSetClientTestCase(APITestCase):
         self.assertTrue(response["X-Sendfile"].find("archives/NGT1_1.0_"))
         self.assertTrue("Content-Disposition" in response)
         self.assertEqual("attachment; filename=NGT0000_0.0_Data_Set_1.zip", response['Content-Disposition'])
+
+        downloadlog = DataSetDownloadLog.objects.all()
+        self.assertEqual(len(downloadlog),1)
+
 
         # Now try to upload and invalid file
         with open('{}/invalid_upload.txt'.format(dirname(__file__)), 'r') as fp:

--- a/ngt_archive/settings.py
+++ b/ngt_archive/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'daterange_filter',
     'archive_api.apps.ArchiveApiConfig',
     'ui.apps.UiConfig',
     'rest_framework',

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(name='ngt_archive',
             "django >= 1.8",
             "djangorestframework == 3.4.3",
             "django-filter ==  0.13.0",
+            "django-daterange-filter == 1.3.0",
             "pyldap",
             "django-auth-ldap == 1.2.8"
       ]


### PR DESCRIPTION
Resolves #115

The solution was to add a new table and track each time a user downloads a dataset via /api/v1/datasets/:id/archive.  This is the only way a user may download a dataset from the archive service.  There is a new Django Admin interface for downloading Dataset Download activity.  This allows the Django admins to filter to download logs by date range or user and to select all the available records to a csv.