### PR TITLE
Notification emails are not being sent

### DIFF
--- a/archive_api/signals.py
+++ b/archive_api/signals.py
@@ -62,14 +62,14 @@ def notify_admin_to_activate_user(sender, user, **kwargs):
 
         else:
             EmailMessage(
-                subject=' {} requesting activation'.format(get_setting("ARCHIVE_API_EMAIL_SUBJECT_PREFIX"), user.get_full_name()),
+                subject=' {} requesting activation'.format(get_setting("EMAIL_SUBJECT_PREFIX"), user.get_full_name()),
                 body="""Dear NGEE Tropics Admins,
 
 User {} is requesting access to NGEE Tropics Archive service.
 
             """.format(user.get_full_name()),
-                to=[get_setting("ARCHIVE_API_EMAIL_NGEET_TEAM")],
-                reply_to=[get_setting("ARCHIVE_API_EMAIL_NGEET_TEAM")]).send()
+                to=[get_setting("EMAIL_NGEET_TEAM")],
+                reply_to=[get_setting("EMAIL_NGEET_TEAM")]).send()
 
 
 # This signal is sent after users log in with default django authentication
@@ -143,13 +143,13 @@ The NGEE Tropics Archive Team
 
     if content:
         EmailMessage(
-            subject='{} Dataset {} ({})'.format(get_setting("ARCHIVE_API_EMAIL_SUBJECT_PREFIX"),
+            subject='{} Dataset {} ({})'.format(get_setting("EMAIL_SUBJECT_PREFIX"),
                                                 archive_api.models.STATUS_CHOICES[int(instance.status)][1],
                                                            instance.data_set_id()),
             body=content,
             to=[instance.created_by.email],
-            cc=[get_setting("ARCHIVE_API_EMAIL_NGEET_TEAM")],
-            reply_to=[get_setting("ARCHIVE_API_EMAIL_NGEET_TEAM")]).send()
+            cc=[get_setting("EMAIL_NGEET_TEAM")],
+            reply_to=[get_setting("EMAIL_NGEET_TEAM")]).send()
 
 
 dataset_status_change.connect(dataset_notify_status_change)

--- a/archive_api/tests/test_api.py
+++ b/archive_api/tests/test_api.py
@@ -44,8 +44,8 @@ class ApiRootClientTestCase(APITestCase):
                           "plots": "http://testserver/api/v1/plots/"})
 
 
-@override_settings(ARCHIVE_API_EMAIL_NGEET_TEAM='ngeet-team@testserver',
-                   ARCHIVE_API_EMAIL_SUBJECT_PREFIX='[ngt-archive-test]')
+@override_settings(EMAIL_NGEET_TEAM='ngeet-team@testserver',
+                   EMAIL_SUBJECT_PREFIX='[ngt-archive-test]')
 class DataSetClientTestCase(APITestCase):
     fixtures = ('test_auth.json', 'test_archive_api.json',)
 

--- a/archive_api/tests/test_signals.py
+++ b/archive_api/tests/test_signals.py
@@ -7,8 +7,8 @@ from django.test import override_settings
 from archive_api.models import Person
 
 
-@override_settings(ARCHIVE_API_EMAIL_NGEET_TEAM='ngeet-team@testserver',
-                   ARCHIVE_API_EMAIL_SUBJECT_PREFIX='[ngt-archive-test]')
+@override_settings(EMAIL_NGEET_TEAM='ngeet-team@testserver',
+                   EMAIL_SUBJECT_PREFIX='[ngt-archive-test]')
 class TestLoginSignals(TestCase):
     fixtures = ('test_auth.json', 'test_archive_api.json',)
 


### PR DESCRIPTION
Resolves #130

This turned out to be an issue with the new settings organization
for archive_api settings.