### PR TITLE
Activation emails should use the username instead

### DIFF
--- a/archive_api/signals.py
+++ b/archive_api/signals.py
@@ -35,7 +35,7 @@ def notify_admin_to_activate_user(sender, user, **kwargs):
     :return:
     """
 
-    if not user.groups.all()  and not user.is_superuser:
+    if not user.groups.all() and not user.is_superuser:
         # check existing list
         # if not in any of these groups send email to admins
 
@@ -61,12 +61,12 @@ def notify_admin_to_activate_user(sender, user, **kwargs):
 
         else:
             EmailMessage(
-                subject=' {} requesting activation'.format(get_setting("EMAIL_SUBJECT_PREFIX"), user.get_full_name()),
+                subject=' {} requesting activation'.format(get_setting("EMAIL_SUBJECT_PREFIX"), user.username),
                 body="""Dear NGEE Tropics Admins,
 
-User {} is requesting access to NGEE Tropics Archive service.
+User '{}' is requesting access to NGEE Tropics Archive service.
 
-            """.format(user.get_full_name()),
+            """.format(user.username),
                 to=get_setting("EMAIL_NGEET_TEAM"),
                 reply_to=get_setting("EMAIL_NGEET_TEAM")).send()
 

--- a/archive_api/tests/test_signals.py
+++ b/archive_api/tests/test_signals.py
@@ -50,7 +50,7 @@ class TestLoginSignals(TestCase):
         self.assertEqual(email.to, ['ngeet-team@testserver'])
         self.assertEqual(email.reply_to, ['ngeet-team@testserver'])
         self.assertTrue(email.subject, "[ngt-archive-test] Barry Allen requesting activation")
-        self.assertTrue(email.body.find("User Barry Allen is requesting access to NGEE Tropics Archive service.") > -1)
+        self.assertTrue(email.body.find("User 'flash' is requesting access to NGEE Tropics Archive service.") > -1)
 
     def test_signal_notify(self):
         user = User.objects.get(username="vibe")
@@ -70,7 +70,7 @@ class TestLoginSignals(TestCase):
         self.assertEqual(email.to, ['ngeet-team@testserver'])
         self.assertEqual(email.reply_to, ['ngeet-team@testserver'])
         self.assertTrue(email.subject, "[ngt-archive-test] Cisco Ramon requesting activation")
-        self.assertTrue(email.body.find("User Cisco Ramon is requesting access to NGEE Tropics Archive service.") > -1)
+        self.assertTrue(email.body.find("User 'vibe' is requesting access to NGEE Tropics Archive service.") > -1)
 
     def test_signal_no_notify(self):
         user = User.objects.get(username="superadmin")


### PR DESCRIPTION
instead of full name

Resolves #134