### PR TITLE
provide previously uploaded filename on drafts

### DIFF
--- a/archive_api/serializers.py
+++ b/archive_api/serializers.py
@@ -1,5 +1,7 @@
 from urllib.parse import urlparse
 
+import os
+
 from archive_api.models import DataSet, MeasurementVariable, Site, Person, Plot, Author
 from django.core.urlresolvers import resolve
 from django.db import transaction
@@ -26,8 +28,6 @@ class StringToIntField(serializers.Field):
 
     def to_representation(self, obj):
         return str(obj)
-
-
 
 
 class AuthorsField(serializers.SerializerMethodField):
@@ -65,12 +65,22 @@ class DataSetSerializer(serializers.HyperlinkedModelSerializer):
     """
     created_by = serializers.ReadOnlyField(source='created_by.username')
     modified_by = serializers.ReadOnlyField(source='modified_by.username')
+    archive_filename = serializers.SerializerMethodField()
     submission_date = serializers.ReadOnlyField()
     authors = AuthorsField()
     archive = serializers.SerializerMethodField()
     status = StringToIntReadOnlyField()
     qaqc_status = StringToIntField(required=False,allow_null=True)
     access_level = StringToIntField(required=False, allow_null=True)
+
+    def get_archive_filename(self,instance):
+
+        if instance.archive:
+
+            base, filename = os.path.split(instance.archive.name)
+            return filename
+        else:
+            return None
 
     def get_archive(self, instance):
         """ Returns the archive access url"""
@@ -113,10 +123,12 @@ class DataSetSerializer(serializers.HyperlinkedModelSerializer):
                   'acknowledgement', 'reference', 'additional_reference_information',
                   'access_level', 'additional_access_information', 'originating_institution',
                   'submission_date', 'contact', 'sites', 'authors', 'plots', 'variables', 'archive',
+                  'archive_filename',
                   'created_by', 'created_date', 'modified_by', 'modified_date'
                   , 'cdiac_import', 'cdiac_submission_contact')
         read_only_fields = ('cdiac_import', 'cdiac_submission_contact',
             'url', 'version', 'created_by', 'created_date', 'modified_by', 'modified_date', 'status', 'archive',
+            'archive_filename',
             'submission_date', 'data_set_id')
 
     def validate(self, data):

--- a/archive_api/tests/test_api.py
+++ b/archive_api/tests/test_api.py
@@ -110,7 +110,8 @@ class DataSetClientTestCase(APITestCase):
         self.assertTrue("X-Sendfile" in response)
         self.assertTrue(response["X-Sendfile"].find("archives/NGT0004_1.0_"))
         self.assertTrue("Content-Disposition" in response)
-        self.assertEqual("attachment; filename=NGT0004_0.0_Unnamed.zip", response['Content-Disposition'])
+
+        self.assertTrue("attachment; filename=Archive_" in response['Content-Disposition'])
 
     def test_client_get(self):
         # Unauthorized user that is not in any groups
@@ -136,7 +137,7 @@ class DataSetClientTestCase(APITestCase):
                                         'http://testserver/api/v1/variables/1/'], 'archive': None,
                           'cdiac_submission_contact': None, 'reference': '', 'additional_access_information': '',
                           'contact': 'http://testserver/api/v1/people/2/', 'acknowledgement': '',
-                          'data_set_id': 'NGT0001',
+                          'data_set_id': 'NGT0001', 'archive_filename': None,
                           'modified_by': 'auser', 'status': '1', 'ngee_tropics_resources': True, 'qaqc_status': None,
                           'end_date': None, 'additional_reference_information': '', 'name': 'Data Set 2',
                           'created_by': 'auser', 'sites': ['http://testserver/api/v1/sites/1/'],
@@ -561,7 +562,7 @@ select "View Approved Datasets" and then click the "Approve" button for NGT0001:
         self.assertTrue("X-Sendfile" in response)
         self.assertTrue(response["X-Sendfile"].find("archives/NGT1_1.0_"))
         self.assertTrue("Content-Disposition" in response)
-        self.assertEqual("attachment; filename=NGT0000_0.0_Data_Set_1.zip", response['Content-Disposition'])
+        self.assertTrue("attachment; filename=Archive_" in response['Content-Disposition'])
 
         downloadlog = DataSetDownloadLog.objects.all()
         self.assertEqual(len(downloadlog),1)
@@ -582,9 +583,9 @@ select "View Approved Datasets" and then click the "Approve" button for NGT0001:
         response = self.client.get('/api/v1/datasets/1/archive/')
         self.assertContains(response, '')
         self.assertTrue("X-Sendfile" in response)
-        self.assertTrue(response["X-Sendfile"].find("archives/0000/0000/NGT0000/0.0/NGT0000_0.0") > -1)
+        self.assertTrue(response["X-Sendfile"].find("archives/0000/0000/NGT0000/0.0/valid_upload") > -1)
         self.assertTrue("Content-Disposition" in response)
-        self.assertEqual("attachment; filename=NGT0000_0.0_Data_Set_1.txt", response['Content-Disposition'])
+        self.assertTrue("attachment; filename=valid_upload_" in response['Content-Disposition'])
 
         response = self.client.put('/api/v1/datasets/1/',
                                    data='{"data_set_id":"FooBarBaz","description":"A FooBarBaz DataSet",'
@@ -635,9 +636,9 @@ You will not be able to view this dataset until it has been approved.
         response = self.client.get('/api/v1/datasets/1/archive/')
         self.assertContains(response, '')
         self.assertTrue("X-Sendfile" in response)
-        self.assertTrue(response["X-Sendfile"].find("archives/0000/0000/NGT0000/1.0/NGT0000_1.0") > -1)
+        self.assertTrue(response["X-Sendfile"].find("archives/0000/0000/NGT0000/1.0/valid_upload") > -1)
         self.assertTrue("Content-Disposition" in response)
-        self.assertEqual("attachment; filename=NGT0000_1.0_Data_Set_1.txt", response['Content-Disposition'])
+        self.assertTrue("attachment; filename=valid_upload_" in response['Content-Disposition'])
 
         import os
         shutil.rmtree(os.path.join(settings.ARCHIVE_API['DATASET_ARCHIVE_ROOT'], "0000"))
@@ -882,9 +883,9 @@ You will not be able to view this dataset until it has been approved.
             self.assertContains(response, '')
             self.assertTrue("X-Sendfile" in response)
             self.assertTrue(
-                response["X-Sendfile"].find("archives/0000/0000/NGT0000/0.0/NGT0000_0.0") > -1)
+                response["X-Sendfile"].find("archives/0000/0000/NGT0000/0.0/bigfile") > -1)
             self.assertTrue("Content-Disposition" in response)
-            self.assertEqual("attachment; filename=NGT0000_0.0_Data_Set_1.dat",
+            self.assertTrue("attachment; filename=bigfile_" in
                              response['Content-Disposition'])
 
         try:


### PR DESCRIPTION
Resolves #204

+ This change is backwards compatible.  It does not require any database migration
+ There will be a new field in the DataSet JSON, "archive_filename". It is read-only
+ When files are upload the datetime is appended. (e.g upload.txt -> upload_2017010118543.txt)
+ The datetime format is yyyymmddHMS.