### PR TITLE
Critical Bug fixes for viewing and submitting datasets

### DIFF
--- a/archive_api/tests/test_api.py
+++ b/archive_api/tests/test_api.py
@@ -323,6 +323,7 @@ select "Edit Drafts" and then click the "Edit" button for NGT0004:FooBarBaz.
         self.assertEqual(status.HTTP_403_FORBIDDEN, response.status_code)
         self.assertEqual({'detail': 'You do not have permission to perform this action.'}, value)
 
+
     def test_admin_approve_workflow(self):
         """
         Test Admin dataset workflow
@@ -736,6 +737,24 @@ You will not be able to view this dataset until it has been approved.
             self.assertContains(response, '"success":true',
                                 status_code=status.HTTP_201_CREATED)
 
+        #########################################################################
+        # NGT User may not SUBMIT a dataset in DRAFT mode if they owne it
+        response = self.client.get("/api/v1/datasets/1/submit/")  # In draft mode, owned by auser
+        value = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual({'detail': 'DataSet has been submitted.', 'success': True}, value)
+
+        # Test unsubmit workflow
+
+        self.login_user("admin")
+        #########################################################################
+        # NGT User may not SUBMIT a dataset in DRAFT mode if they owne it
+        response = self.client.get("/api/v1/datasets/1/unsubmit/")  # In draft mode, owned by auser
+        value = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual({'detail': 'DataSet has been unsubmitted.', 'success': True}, value)
+
+        self.login_user("auser")
         #########################################################################
         # NGT User may not SUBMIT a dataset in DRAFT mode if they owne it
         response = self.client.get("/api/v1/datasets/1/submit/")  # In draft mode, owned by auser

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -2,6 +2,13 @@
 Releases
 ========
 
+v1.1.1
+======
+Critical Bug fixes
+
+- DataSet Workflow: Can't Unsubmit and then Resubmit a dataset **bug,critical** (`#295  <https://github.com/NGEET/ngt-archive/issues/295>`_)
+- Incorrect Meta Data on Edit Dataset Screen **bug,critical** (`#294  <https://github.com/NGEET/ngt-archive/issues/294>`_)
+
 v1.1.0
 ======
 Bug fixes and usability enhancements


### PR DESCRIPTION
Closes #295 - Skipping file copy when draft version is already 1.0
Closes #294 - filtering out removed datasets (status = -1) from the REST API.  This is a temporary fix until the UI code is addressed