### PR TITLE
Removed hard coded googlemaps api key

### DIFF
--- a/main.copyme
+++ b/main.copyme
@@ -5,6 +5,7 @@ db_host: localhost
 db_port: ''
 
 secret_key: 'changemeto a secret'
+google_maps_key: 'add google maps key here'
 
 
 ldap_bind_password: <change to ldap bind password >

--- a/ngt_archive/settings.py
+++ b/ngt_archive/settings.py
@@ -15,7 +15,7 @@ import sys
 
 import os
 
-
+LOGIN_URL = "/api/api-auth/login/"
 EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -157,10 +157,12 @@ ARCHIVE_API = {
     'DATASET_ADMIN_MAX_UPLOAD_SIZE': 2147483648, # in bytes
     'DATASET_USER_MAX_UPLOAD_SIZE': 1073741824, # in bytes
     'EMAIL_NGEET_TEAM': ['ngeet-team@testserver'],
-    'EMAIL_SUBJECT_PREFIX' : '[ngt-archive-test]'
+    'EMAIL_SUBJECT_PREFIX' : '[ngt-archive-test]',
+
 
 }
 
+GOOGLE_MAPS_KEY="a secret key"
 
 try:
     try:

--- a/settings_local_py.jinja2
+++ b/settings_local_py.jinja2
@@ -73,3 +73,5 @@ AUTHENTICATION_BACKENDS = (
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 DATASET_ARCHIVE_ROOT="{{ project_root }}/archives"
+
+GOOGLE_MAPS_KEY="{{ google_maps_key }}"

--- a/ui/templates/ui/index.html
+++ b/ui/templates/ui/index.html
@@ -15,7 +15,7 @@
         <link rel="stylesheet" type="text/css" href="static/js/jquery-ui/jquery-ui.css">
         <link rel="stylesheet" type="text/css" href="static/js/jquery-ui/jquery-ui.theme.css">
         <link rel="stylesheet" type="text/css" href="static/js/jquery-ui/jquery-ui.structure.css">
-        <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAllKgUfxh6WQorM4b-vnIBjY1kRGwG86g"></script>
+        <script async defer src="https://maps.googleapis.com/maps/api/js?key={{ google_maps_key }}"></script>
         <script type="text/javascript" src="static/js/bootstrap.min.js"></script>
         <link rel="stylesheet" type="text/css" href="static/stylesheets/popover.css">
     </head>

--- a/ui/tests.py
+++ b/ui/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/ui/tests/test_index.py
+++ b/ui/tests/test_index.py
@@ -1,0 +1,31 @@
+from django.contrib.auth.models import User
+from django.test import TestCase, Client
+from django.conf import settings
+
+
+class TestIndex(TestCase):
+    fixtures = ('test_auth.json', 'test_archive_api.json',)
+
+    def setUp(self):
+        # Every test needs a client.
+        self.client = Client()
+
+    def test_index(self):
+        """ Test that the home page comes up with a login
+        """
+        # Issue a GET request.
+        response = self.client.get('/', follow=True)
+
+        # Check that the response is 200 OK.
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Log in with your FLUXNET credentials")
+        self.assertNotContains(response, "key={}".format(settings.GOOGLE_MAPS_KEY))
+
+        # Login
+        user = User.objects.get(username="auser")
+        self.client.force_login(user)
+
+        # Check that the response is 200 OK.
+        response = self.client.get('/', follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "key={}".format(settings.GOOGLE_MAPS_KEY))

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -1,6 +1,8 @@
 from django.conf.urls import url
-from django.views.generic.base import TemplateView
+from django.contrib.auth.decorators import login_required
+
+from ui.views import IndexView
 
 urlpatterns = [
-    url(r'^$', TemplateView.as_view(template_name='ui/index.html'), name="home"),
+    url(r'^$', login_required(IndexView.as_view()), name="home"),
 ]

--- a/ui/views.py
+++ b/ui/views.py
@@ -1,3 +1,16 @@
+from django.conf import settings
 from django.shortcuts import render
 
 # Create your views here.
+from django.views.generic import TemplateView
+
+
+class IndexView(TemplateView):
+    template_name = 'ui/index.html'
+
+    def get_context_data(self, **kwargs):
+        context = super(IndexView, self).get_context_data(**kwargs)
+        context['google_maps_key'] = settings.GOOGLE_MAPS_KEY
+
+        return context
+


### PR DESCRIPTION
Closes #307

The following changes will make it possible to generate a new
Google maps key using an NGEE Tropics google account.

+ Created a Django View class for the index page (IndexView)
+ Wrapped a login_required decorator around the IndexView
+ Added config settings.GOOGLE_MAPS_KEY
+ Updated LOGIN_URL in settings to /api/api-auth/login/