### PR TITLE
Warning in logs for Django ORM models

### DIFF
--- a/archive_api/apps.py
+++ b/archive_api/apps.py
@@ -51,6 +51,7 @@ def load_groups(sender, **kwargs):
 
 class ArchiveApiConfig(AppConfig):
     name = 'archive_api'
+    default_auto_field = 'django.db.models.AutoField'
 
     def ready(self):
         post_migrate.connect(load_groups, sender=self)


### PR DESCRIPTION
Configures the ArchiveApiConfig.default_auto_field attribute to point to a subclass of
AutoField, e.g. 'django.db.models.BigAutoField'.

Closes #339