### PR TITLE
Strips empty lines from ESS-DIVE citation field

### DIFF
--- a/archive_api/fixtures/test_essdive_transfer.json
+++ b/archive_api/fixtures/test_essdive_transfer.json
@@ -48,7 +48,7 @@
       "doe_funding_contract_numbers": "DE-SC0012704",
       "acknowledgement": "This research was supported as part of NGEE-Tropics, funded by the U.S. Department of Energy, Office of Science, Office of Biological and Environmental Research under contract no. DE-SC0012704.",
       "reference": "Larson, Kristine & Small, Eric & Gutmann, Ethan & Bilich, Andria & Braun, John & Zavorotny, Valery & Larson, Citation. (2008). Use of GPS receivers as a soil moisture network for water cycle studies. Geophysical Research Letters - GEOPHYS RES LETT. 35. 10.1029/2008GL036013. Solander et al.: The pantropical response of soil moisture to El Niño, Hydrol. Earth Syst. Sci., 24, 2303–2322, https://doi.org/10.5194/hess-24-2303-2020, 2020.",
-      "additional_reference_information": "this is my additional reference information",
+      "additional_reference_information": "this is my additional reference information\n\nMore stuff",
       "originating_institution": "Brookhaven National Laboratory",
       "access_level": 1,
       "additional_access_information": "Stuff that is additional information",

--- a/archive_api/service/essdive_transfer/crosswalk.py
+++ b/archive_api/service/essdive_transfer/crosswalk.py
@@ -195,10 +195,11 @@ def dataset_transform(dataset):
 
     # ---- related reference ----
 
-    citation = dataset.reference and dataset.reference.split('\n') or list()
+    # Strip empty lines (ESS-DIVE api does not allow that for these fields)
+    citation = dataset.reference and [r for r in dataset.reference.split('\n') if r] or list()
     if dataset.additional_reference_information:
         citation.append(f"Additional information about citations:")
-        citation.extend(dataset.additional_reference_information.split("\n"))
+        citation.extend([r for r in dataset.additional_reference_information.split("\n") if r])
 
     # ---- creators ----
     creators = _dataset_creator(dataset)

--- a/archive_api/tests/essdive-transfer.jsonld
+++ b/archive_api/tests/essdive-transfer.jsonld
@@ -7,7 +7,8 @@
   "citation": [
     "Larson, Kristine & Small, Eric & Gutmann, Ethan & Bilich, Andria & Braun, John & Zavorotny, Valery & Larson, Citation. (2008). Use of GPS receivers as a soil moisture network for water cycle studies. Geophysical Research Letters - GEOPHYS RES LETT. 35. 10.1029/2008GL036013. Solander et al.: The pantropical response of soil moisture to El Niño, Hydrol. Earth Syst. Sci., 24, 2303–2322, https://doi.org/10.5194/hess-24-2303-2020, 2020.",
     "Additional information about citations:",
-    "this is my additional reference information"
+    "this is my additional reference information",
+    "More stuff"
   ],
   "description": [
     "This data package includes leaf traits, canopy traits and sample details for leaves from 71 species sampled from the San Lorenzo forest canopy crane site, Panama (PA-SLZ) during the BNL field campaign in January to March 2020. Each leaf sample is described with species, phenological stage and location within vertical canopy profiles. Leaf area index (LAI) and height is presented for each canopy profile location. Leaf mass per area (LMA), leaf water content (LWC) and leaf carbon and nitrogen content are included for a subset of the samples. This data package includes sample details, processed data for leaf traits and LAI (*.csv), LAI raw data (compressed as *.zip) and digital camera images (*.jpg, compressed as *.zip) of the leaf samples. Metadata files include data descriptions (_dd.csv) for tabular data, a list of all species sampled during the campaign (*.csv) and a detailed description of the field campaign protocol and methods (*.pdf). See related datasets for leaf gas exchange, leaf water potential and leaf spectral measurements made on the samples described here.",


### PR DESCRIPTION
+ ESS-DIVE does not allow empty strings in the citation field list.

Closes #382