### PR TITLE
Pins python image to 3.9.16 (openssl 1.1.1n)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /app
 # Run OS updates
 # create unprivileged user, create application directories, and ensure proper permissions
 # Install application dependencies
-RUN apt-get update &&  apt-get install -y --no-install-recommends libldap2-dev libsasl2-dev libssl-dev netcat-traditional\
+RUN apt-get update &&  apt-get install -y --no-install-recommends  netcat python-dev libldap2-dev libsasl2-dev libssl-dev \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd -g ${GID} webapp \
     && useradd -u ${UID} -g ${GID} -c 'Web app User' webapp \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.9
+ARG PYTHON_VERSION=3.9.16
 FROM python:${PYTHON_VERSION}
 MAINTAINER Valerie Hendrix <vchendrix@lbl.gov>
 


### PR DESCRIPTION
Solution to issue is to pin the python docker image to 3.9.16 which uses OpenSSL 1.1.1n  15 Mar 2022.   This reverts commit 4c707174400c847890b3ec6cf9e6b2bcb1f0edac.
