### PR TITLE
bug(transfer): Prevents old dataset transfer

### DIFF
--- a/archive_api/service/essdive_transfer/tasks.py
+++ b/archive_api/service/essdive_transfer/tasks.py
@@ -101,10 +101,12 @@ def transfer_start(run_id):
                 f"Determining if ESS-DIVE dataset ({previous_jobs[0].response['id']}) represents {transfer_job.dataset.data_set_id()}")
             essdive_response = get(previous_jobs[0].response['id'])
             if essdive_response.status_code == status.HTTP_200_OK:
-                transfer_job.status = EssDiveTransfer.STATUS_QUEUED
-                transfer_job.save()
-                log.info(f"Found ESS-DIVE dataset ({previous_jobs[0].response['id']}) for {transfer_job.dataset.data_set_id()}")
-                essdive_id = previous_jobs[0].response['id']
+                # Make sure the ESS-DIVE dataset is the current dataset
+                if essdive_response.json()['next'] is None:
+                    transfer_job.status = EssDiveTransfer.STATUS_QUEUED
+                    transfer_job.save()
+                    log.info(f"Found ESS-DIVE dataset ({previous_jobs[0].response['id']}) for {transfer_job.dataset.data_set_id()}")
+                    essdive_id = previous_jobs[0].response['id']
 
             else:
                 # It is OK if there was a previous job but none was found.  This might mean that

--- a/archive_api/tests/ngt_essdive_dataset.json
+++ b/archive_api/tests/ngt_essdive_dataset.json
@@ -1,6 +1,9 @@
 {
     "id": "ess-dive-e1902f9728f70db-20220430T030400919221",
     "viewUrl": "https://data-sandbox.ess-dive.lbl.gov/view/ess-dive-e1902f9728f70db-20220430T030400919221",
+    "url": "https://api.ess-dive.lbl.gov/packages/ess-dive-e1902f9728f70db-20220430T030400919221",
+    "next": null,
+    "previous": "https://api.ess-dive.lbl.gov/packages/ess-dive-3fbdb62c053b39f-20230927T031340386",
     "dateUploaded": "2022-04-30T03:04:01.310Z",
     "dateModified": "2022-04-30T03:04:01.310Z",
     "isPublic": false,

--- a/archive_api/tests/ngt_essdive_dataset_duplicate.json
+++ b/archive_api/tests/ngt_essdive_dataset_duplicate.json
@@ -1,6 +1,9 @@
 {
     "id": "ess-dive-e1902f9728f70db-20220530T030400919221",
     "viewUrl": "https://data-sandbox.ess-dive.lbl.gov/view/ess-dive-e1902f9728f70db-20220530T030400919221",
+    "url": "https://api.ess-dive.lbl.gov/packages/ess-dive-e1902f9728f70db-20220430T030400919221",
+    "next": null,
+    "previous": "https://api.ess-dive.lbl.gov/packages/ess-dive-3fbdb62c053b39f-20230927T031340386",
     "dateUploaded": "2022-04-30T03:04:01.310Z",
     "dateModified": "2022-04-30T03:04:01.310Z",
     "isPublic": false,

--- a/archive_api/tests/ngt_essdive_dataset_result.json
+++ b/archive_api/tests/ngt_essdive_dataset_result.json
@@ -10,6 +10,9 @@
         {
             "id": "ess-dive-e1902f9728f70db-20220430T030400919221",
             "viewUrl": "https://data-sandbox.ess-dive.lbl.gov/view/ess-dive-e1902f9728f70db-20220430T030400919221",
+            "url": "https://api.ess-dive.lbl.gov/packages/ess-dive-e1902f9728f70db-20220430T030400919221",
+            "next": null,
+            "previous": "https://api.ess-dive.lbl.gov/packages/ess-dive-3fbdb62c053b39f-20230927T031340386",
             "dateUploaded": "2022-04-30T03:04:01.310Z",
             "dateModified": "2022-04-30T03:04:01.310Z",
             "isPublic": false,

--- a/archive_api/tests/ngt_essdive_dataset_result_duplicate.json
+++ b/archive_api/tests/ngt_essdive_dataset_result_duplicate.json
@@ -10,6 +10,9 @@
         {
             "id": "ess-dive-e1902f9728f70db-20220430T030400919221",
             "viewUrl": "https://data-sandbox.ess-dive.lbl.gov/view/ess-dive-e1902f9728f70db-20220430T030400919221",
+            "url": "https://api.ess-dive.lbl.gov/packages/ess-dive-e1902f9728f70db-20220430T030400919221",
+            "next": null,
+            "previous": "https://api.ess-dive.lbl.gov/packages/ess-dive-3fbdb62c053b39f-20230927T031340386",
             "dateUploaded": "2022-04-30T03:04:01.310Z",
             "dateModified": "2022-04-30T03:04:01.310Z",
             "isPublic": false,
@@ -26,6 +29,9 @@
         {
             "id": "ess-dive-e1902f9728f70db-20220530T030400919221",
             "viewUrl": "https://data-sandbox.ess-dive.lbl.gov/view/ess-dive-e1902f9728f70db-20220430T030500919221",
+            "url": "https://api.ess-dive.lbl.gov/packages/ess-dive-e1902f9728f70db-20220430T030400919221",
+            "next": null,
+            "previous": "https://api.ess-dive.lbl.gov/packages/ess-dive-3fbdb62c053b39f-20230927T031340386",
             "dateUploaded": "2022-04-30T03:04:01.310Z",
             "dateModified": "2022-04-30T03:04:01.310Z",
             "isPublic": false,


### PR DESCRIPTION
Confirms that the previous dataset transfered is still the current dataset before trying to use the identifier to transfer dataset.

Closes #409