### PR TITLE
bug(metadata): Allows empty funding organization on submission

### DIFF
--- a/archive_api/serializers.py
+++ b/archive_api/serializers.py
@@ -169,7 +169,7 @@ class DataSetSerializer(serializers.HyperlinkedModelSerializer):
                 errors['missingRequiredFields'].append("archive")
 
             for field in ['sites', 'authors', 'name', 'description', 'contact', 'variables',
-                          'ngee_tropics_resources', 'funding_organizations', 'originating_institution',
+                          'ngee_tropics_resources', 'originating_institution',
                           'access_level', 'qaqc_method_description']:  # Check for required fields
                 if field in data.keys():
                     if data[field] is None or (isinstance(data[field], (list, tuple, str)) and not data[field]):

--- a/archive_api/tests/test_api.py
+++ b/archive_api/tests/test_api.py
@@ -226,7 +226,6 @@ You can also login with your account credentials, select "Edit Drafts" and then 
                                                     'contact',
                                                     'variables',
                                                     'ngee_tropics_resources',
-                                                    'funding_organizations',
                                                     'originating_institution',
                                                     'qaqc_method_description']}, value)
 
@@ -331,7 +330,7 @@ You can also login with your account credentials, select "Edit Drafts" and then 
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
         self.assertEqual(
             {'description': ['Description must be at least 100 words. Current count is 37.'],
-             'missingRequiredFields': ['archive', 'authors', 'funding_organizations', 'originating_institution',
+             'missingRequiredFields': ['archive', 'authors', 'originating_institution',
                                        'qaqc_method_description']},
             value)
 
@@ -388,7 +387,7 @@ You can also login with your account credentials, select "Edit Drafts" and then 
         value = json.loads(response.content.decode('utf-8'))
         self.assertEqual(
             {'description': ['Description must be at least 100 words. Current count is 37.'],
-             'missingRequiredFields': ['archive', 'authors', 'funding_organizations', 'originating_institution',
+             'missingRequiredFields': ['archive', 'authors', 'originating_institution',
                                        'qaqc_method_description']},
             value)
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)


### PR DESCRIPTION
Before the use of a default funding organization this funding organization was required on Dataset Submission for review. Now it is no longer require since BER will be the default funding organization.

Closes #432