### PR TITLE
feat(essdive): adds location rf to jsonld

### DIFF
--- a/archive_api/service/essdive_transfer/crosswalk.py
+++ b/archive_api/service/essdive_transfer/crosswalk.py
@@ -14,6 +14,7 @@ import logging
 
 # NGEE-Tropics Project information
 LOCATION_NOT_APPLICABLE = "N/A"
+LOCATION_RF_KEYWORD = "ESS-DIVE Location Metadata Reporting Format"
 JSONLD_PROVIDER = {
     "identifier": {
       "@type": "PropertyValue",
@@ -23,7 +24,7 @@ JSONLD_PROVIDER = {
 }
 
 # NGEE-Tropics Keywords
-JSONLD_KEYWORDS = ["Next-Generation Ecosystem Experiements Tropics", "NGEE-T"]
+JSONLD_KEYWORDS = ["Next-Generation Ecosystem Experiements Tropics", "NGEE-T", LOCATION_RF_KEYWORD]
 
 # CC By 4 License
 JSONLD_LICENSE = "http://creativecommons.org/licenses/by/4.0/"

--- a/archive_api/tests/essdive-transfer.jsonld
+++ b/archive_api/tests/essdive-transfer.jsonld
@@ -33,7 +33,8 @@
   "datePublished": "2021-06-18",
   "keywords": [
     "Next-Generation Ecosystem Experiements Tropics",
-    "NGEE-T"
+    "NGEE-T",
+    "ESS-DIVE Location Metadata Reporting Format"
   ],
   "variableMeasured": [
     "Ice",


### PR DESCRIPTION
ESS-DIVE uses a keyword (“ESS-DIVE Location Metadata Reporting Format”) to sign that a dataset contains the location reporting format file within the dataset's data files. We need to update this metadata field for all NGEE-Tropics datasets in ESS-DIVE.

Closes #486